### PR TITLE
Formatting fixes, documentation, and a rename (note: breaking changes)

### DIFF
--- a/Coolbooru/Coolbooru.cs
+++ b/Coolbooru/Coolbooru.cs
@@ -121,6 +121,9 @@ namespace Coolbooru {
 		/// The image's source URL, if provided.
 		/// </summary>
 		public string source_url;
+		/// <summary>
+		/// Available "representations", or different sizes, of the image.
+		/// </summary>
 		public CoolRepresentation representations;
 		/// <summary>
 		/// Whether or not the image was "rendered" by Derpibooru.
@@ -324,9 +327,9 @@ namespace Coolbooru {
 		/// <summary>
 		/// The field to search and sort by. See the CONSTRAINT_* constants.
 		/// </summary>
-		/// <see cref="Coolbooru.CONSTRAINT_ID"/>
-		/// <seealso cref="Coolbooru.CONSTRAINT_CREATED"/>
-		/// <seealso cref="Coolbooru.CONSTRAINT_UPDATED"/>
+		/// <see cref="CoolStuff.CONSTRAINT_ID"/>
+		/// <seealso cref="CoolStuff.CONSTRAINT_CREATED"/>
+		/// <seealso cref="CoolStuff.CONSTRAINT_UPDATED"/>
 		public string Constraint;
 		/// <summary>
 		/// The page of results to return. Defaults to 1.
@@ -483,7 +486,7 @@ namespace Coolbooru {
 	/// <summary>
 	/// The main functions of Coolbooru.
 	/// </summary>
-	public class CoolRequests {
+	public class CoolStuff {
 		/// <summary>
 		/// The ID constraint for use with List searches.
 		/// </summary>

--- a/Coolbooru/Coolbooru.cs
+++ b/Coolbooru/Coolbooru.cs
@@ -689,8 +689,8 @@ namespace Coolbooru {
 		/// <param name="q">A CoolImageQuery representing the query.</param>
 		/// <returns>A CoolImages object representing the result.</returns>
 		public static async Task<CoolImages> Images(CoolImageQuery q) {
-			string url = "https://derpibooru.org/images.json?page=" + q.page;
-			if (q.APIKey != null) url += "&key=" + q.key;
+			string url = "https://derpibooru.org/images.json?page=" + q.Page;
+			if (q.APIKey != null) url += "&key=" + q.APIKey;
 			if (q.Constraint != null) {
 				if (q.Constraint == CONSTRAINT_ID) {
 					if (q.IDGreaterThan != null)

--- a/Coolbooru/Coolbooru.cs
+++ b/Coolbooru/Coolbooru.cs
@@ -137,27 +137,27 @@ namespace Coolbooru {
 	/// </summary>
 	public class CoolRepresentation {
 		/// <summary>
-		/// A very small thumbnail for the image.
+		/// A URL that points to a very small thumbnail for the image.
 		/// </summary>
 		public string thumb_tiny;
 		/// <summary>
-		/// A small thumbnail for the image.
+		/// A URL that points to a small thumbnail for the image.
 		/// </summary>
 		public string thumb_small;
 		/// <summary>
-		/// A thumbnail for the image.
+		/// A URL that points to a thumbnail for the image.
 		/// </summary>
 		public string thumb;
 		/// <summary>
-		/// A small version of the image.
+		/// A URL that points to a small version of the image.
 		/// </summary>
 		public string small;
 		/// <summary>
-		/// A medium version of the image.
+		/// A URL that points to a medium version of the image.
 		/// </summary>
 		public string medium;
 		/// <summary>
-		/// A full-resolution version of the image.
+		/// A URL that points to a full-resolution version of the image.
 		/// </summary>
 		public string full;
 	}

--- a/Coolbooru/Coolbooru.cs
+++ b/Coolbooru/Coolbooru.cs
@@ -166,8 +166,17 @@ namespace Coolbooru {
 	/// Represents the default Lists available.
 	/// </summary>
 	public class CoolLists {
+		/// <summary>
+		/// The default top scoring list.
+		/// </summary>
 		public List<CoolItem> top_scoring;
+		/// <summary>
+		/// The default top commented list.
+		/// </summary>
 		public List<CoolItem> top_commented;
+		/// <summary>
+		/// The list of all time top scoring images.
+		/// </summary>
 		public List<CoolItem> all_time_top_scoring;
 		public List<object> interactions;
 	}

--- a/Coolbooru/Coolbooru.cs
+++ b/Coolbooru/Coolbooru.cs
@@ -474,7 +474,7 @@ namespace Coolbooru {
 	/// <summary>
 	/// The main functions of Coolbooru.
 	/// </summary>
-	public class Coolbooru {
+	public class CoolRequests {
 		/// <summary>
 		/// The ID constraint for use with List searches.
 		/// </summary>

--- a/Coolbooru/Coolbooru.cs
+++ b/Coolbooru/Coolbooru.cs
@@ -197,7 +197,6 @@ namespace Coolbooru {
 	/// The main functions of Coolbooru.
 	/// </summary>
 	public class Coolbooru {
-
 		public const string CONSTRAINT_ID = "id";
 		public const string CONSTRAINT_UPDATED = "updated";
 		public const string CONSTRAINT_CREATED = "created";
@@ -213,7 +212,7 @@ namespace Coolbooru {
 		/// Creates a new HTTP client for use with API calls.
 		/// </summary>
 		/// <returns>a new HTTP client for use with API calls.</returns>
-		private static HttpClient clientFactory() {
+		private static HttpClient ClientFactory() {
 			HttpClient c = new HttpClient();
 			c.DefaultRequestHeaders.UserAgent.ParseAdd("Coolbooru");
 			return c;
@@ -225,8 +224,8 @@ namespace Coolbooru {
 		/// <typeparam name="T">Model to serialize to.</typeparam>
 		/// <param name="url">URL to query.</param>
 		/// <returns>Response based on the model passed in.</returns>
-		private static async Task<T> doResponse<T>(string url) {
-			return JsonConvert.DeserializeObject<T>(await clientFactory().GetStringAsync(url));
+		private static async Task<T> DoResponse<T>(string url) {
+			return JsonConvert.DeserializeObject<T>(await ClientFactory().GetStringAsync(url));
 		}
 
 		/// <summary>
@@ -236,8 +235,8 @@ namespace Coolbooru {
 		/// <param name="query">The tag(s) to search for (e.g. pinkie pie)</param>
 		/// <param name="page">Pagination</param>
 		/// <returns>A CoolSearch representing the result</returns>
-		public static async Task<CoolSearch> search(string query, int page = 1) {
-			return await doResponse<CoolSearch>("https://derpibooru.org/search.json?q=" + Uri.EscapeUriString(query) + "&page=" + page);
+		public static async Task<CoolSearch> Search(string query, int page = 1) {
+			return await DoResponse<CoolSearch>("https://derpibooru.org/search.json?q=" + Uri.EscapeUriString(query) + "&page=" + page);
 		}
 
 		/// <summary>
@@ -245,14 +244,14 @@ namespace Coolbooru {
 		/// </summary>
 		/// <param name="q">A CoolSearchQuery object</param>
 		/// <returns>A CoolSearch representing the result</returns>
-		public static async Task<CoolSearch> search(CoolSearchQuery q) {
+		public static async Task<CoolSearch> Search(CoolSearchQuery q) {
 			string url = "https://derpibooru.org/search.json?q=" + q.q + "&page=" + q.page;
 			if (q.key != null) url += "&key=" + q.key;
 			if (q.comments) url += "&comments=true";
 			if (q.fav) url += "&fav=true";
 			if (q.sf != null) url += "&sf=" + q.sf;
 
-			return await doResponse<CoolSearch>(url);
+			return await DoResponse<CoolSearch>(url);
 		}
 
 		/// <summary>
@@ -260,16 +259,16 @@ namespace Coolbooru {
 		/// </summary>
 		/// <param name="itemID">An item ID.</param>
 		/// <returns>A CoolItem representing the result</returns>
-		public static async Task<CoolItem> item(int itemID) {
-			return await doResponse<CoolItem>("https://derpibooru.org/" + itemID + ".json");
+		public static async Task<CoolItem> Item(int itemID) {
+			return await DoResponse<CoolItem>("https://derpibooru.org/" + itemID + ".json");
 		}
 
 		/// <summary>
 		/// Get the contents of lists top_scoring, top_commented, all_time_top_scoring
 		/// </summary>
 		/// <returns>A CoolLists object representing the result</returns>
-		public static async Task<CoolLists> lists() {
-			return await doResponse<CoolLists>("https://derpibooru.org/lists.json");
+		public static async Task<CoolLists> Lists() {
+			return await DoResponse<CoolLists>("https://derpibooru.org/lists.json");
 		}
 
 		/// <summary>
@@ -277,8 +276,8 @@ namespace Coolbooru {
 		/// </summary>
 		/// <param name="list">The list to get the contents of.</param>
 		/// <returns>A CoolList object representing the result</returns>
-		public static async Task<CoolList> list(string list, int page = 1) {
-			return await doResponse<CoolList>("https://derpibooru.org/lists/" + list + ".json&page=" + page);
+		public static async Task<CoolList> List(string list, int page = 1) {
+			return await DoResponse<CoolList>("https://derpibooru.org/lists/" + list + ".json&page=" + page);
 		}
 
 
@@ -287,21 +286,13 @@ namespace Coolbooru {
 		/// </summary>
 		/// <param name="q">A CoolListQuery representing the parameters of the request.</param>
 		/// <returns>A CoolList object representing the result</returns>
-		public static async Task<CoolList> list(CoolListQuery q) {
+		public static async Task<CoolList> List(CoolListQuery q) {
 			string url = "https://derpibooru.org/lists/" + q.list + ".json?page=" + q.page;
 			if (q.key != null) url += "&key=" + q.key;
 			if (q.comments) url += "&comments=true";
 			if (q.fav) url += "&fav=true";
 
-			return await doResponse<CoolList>(url);
-		}
-
-		/// <summary>
-		/// Get the front-page images.
-		/// </summary>
-		/// <returns>A CoolImages object representing the result</returns>
-		public static async Task<CoolImages> images() {
-			return await doResponse<CoolImages>("https://derpibooru.org/images.json");
+			return await DoResponse<CoolList>(url);
 		}
 
 		/// <summary>
@@ -309,8 +300,8 @@ namespace Coolbooru {
 		/// </summary>
 		/// <param name="user">The user whose galleries you want to get.</param>
 		/// <returns>A List of CoolGalleries representing the result</returns>
-		public static async Task<List<CoolGallery>> userGalleries(string user) {
-			return await doResponse<List<CoolGallery>>("https://derpibooru.org/galleries/" + user + ".json");
+		public static async Task<List<CoolGallery>> UserGalleries(string user) {
+			return await DoResponse<List<CoolGallery>>("https://derpibooru.org/galleries/" + user + ".json");
 		}
 
 		/// <summary>
@@ -320,11 +311,11 @@ namespace Coolbooru {
 		/// <param name="page">Pagination.</param>
 		/// <param name="include_images">"When set, include arrays of image IDs featured in each gallery, in the order defined by the owning user, disregarding content filters." Doesn't seem to do much, though.</param>
 		/// <returns>A List of CoolGalleries representing the result</returns>
-		public static async Task<List<CoolGallery>> userGalleries(string user, int page = 1, bool include_images = false) {
+		public static async Task<List<CoolGallery>> UserGalleries(string user, int page = 1, bool include_images = false) {
 			string url = "https://derpibooru.org/galleries/" + user + ".json?page=" + page;
 			if (include_images) url += "&include_images=true";
 
-			return await doResponse<List<CoolGallery>>(url);
+			return await DoResponse<List<CoolGallery>>(url);
 		}
 
 		/// <summary>
@@ -334,9 +325,9 @@ namespace Coolbooru {
 		/// <param name="id">The gallery ID.</param>
 		/// <param name="page">Pagination.</param>
 		/// <returns>A CoolGallery representing the result.</returns>
-		public static async Task<CoolGallery> userGallery(string user, int id, int page = 1) {
+		public static async Task<CoolGallery> UserGallery(string user, int id, int page = 1) {
 			string url = "https://derpibooru.org/galleries/" + user + "/" + id + ".json?page=" + page;
-			return await doResponse<CoolGallery>(url);
+			return await DoResponse<CoolGallery>(url);
 		}
 
 		/// <summary>
@@ -345,8 +336,8 @@ namespace Coolbooru {
 		/// <param name="id">The gallery ID.</param>
 		/// <param name="page">Pagination.</param>
 		/// <returns>A CoolGallery representing the result.</returns>
-		public static async Task<CoolGallery> userGallery(int id, int page = 1) {
-			return await doResponse<CoolGallery>("https://derpibooru.org/galleries/" + id + ".json?page=" + page);
+		public static async Task<CoolGallery> UserGallery(int id, int page = 1) {
+			return await DoResponse<CoolGallery>("https://derpibooru.org/galleries/" + id + ".json?page=" + page);
 		}
 
 		/// <summary>
@@ -354,7 +345,7 @@ namespace Coolbooru {
 		/// </summary>
 		/// <param name="q">A CoolUserGalleryQuery object</param>
 		/// <returns>A CoolGallery representing the result.</returns>
-		public static async Task<CoolGallery> userGallery(CoolUserGalleryQuery q) {
+		public static async Task<CoolGallery> UserGallery(CoolUserGalleryQuery q) {
 			string url = "https://derpibooru.org/galleries/";
 			if (q.user != null && q.id != null)
 				url += q.user + "/" + q.id + ".json";
@@ -367,7 +358,15 @@ namespace Coolbooru {
 			if (q.include_images) url += "&include_images=true";
 			if (q.key != null) url += "&key=" + q.key;
 
-			return await doResponse<CoolGallery>(url);
+			return await DoResponse<CoolGallery>(url);
+		}
+
+		/// <summary>
+		/// Get the front-page images.
+		/// </summary>
+		/// <returns>A CoolImages object representing the result</returns>
+		public static async Task<CoolImages> Images() {
+			return await DoResponse<CoolImages>("https://derpibooru.org/images.json");
 		}
 
 		/// <summary>
@@ -375,7 +374,7 @@ namespace Coolbooru {
 		/// </summary>
 		/// <param name="q">A CoolImageQuery representing the query.</param>
 		/// <returns>A CoolImages object representing the result.</returns>
-		public static async Task<CoolImages> images(CoolImageQuery q) {
+		public static async Task<CoolImages> Images(CoolImageQuery q) {
 			string url = "https://derpibooru.org/images.json?page=" + q.page;
 			if (q.key != null) url += "&key=" + q.key;
 			if (q.constraint != null) url += "&constraint=" + q.constraint;
@@ -389,7 +388,7 @@ namespace Coolbooru {
 			if (q.fav) url += "&fav=true";
 			if (q.random_image) url += "&random_image=true";
 
-			return await doResponse<CoolImages>(url);
+			return await DoResponse<CoolImages>(url);
 		}
 
 		/// <summary>
@@ -397,8 +396,8 @@ namespace Coolbooru {
 		/// </summary>
 		/// <param name="id">A post ID.</param>
 		/// <returns>A CoolEmbed object representing the result.</returns>
-		public static async Task<CoolEmbed> embed(int id) {
-			return await doResponse<CoolEmbed>("https://derpibooru.org/oembed.json?url=https://derpibooru.org/" + id);
+		public static async Task<CoolEmbed> Embed(int id) {
+			return await DoResponse<CoolEmbed>("https://derpibooru.org/oembed.json?url=https://derpibooru.org/" + id);
 		}
 
 		/// <summary>
@@ -406,8 +405,8 @@ namespace Coolbooru {
 		/// </summary>
 		/// <param name="url">A URL.</param>
 		/// <returns>A CoolEmbed object representing the result.</returns>
-		public static async Task<CoolEmbed> embed(string url) {
-			return await doResponse<CoolEmbed>("https://derpibooru.org/oembed.json?url=" + url);
+		public static async Task<CoolEmbed> Embed(string url) {
+			return await DoResponse<CoolEmbed>("https://derpibooru.org/oembed.json?url=" + url);
 		}
 	}
 }

--- a/Coolbooru/Coolbooru.cs
+++ b/Coolbooru/Coolbooru.cs
@@ -9,7 +9,13 @@ namespace Coolbooru {
 	/// Represents a search query.
 	/// </summary>
 	public class CoolSearch {
+		/// <summary>
+		/// The list of images (CoolItems) returned from Derpibooru.
+		/// </summary>
 		public List<CoolItem> search;
+		/// <summary>
+		/// The total number of images with the given tag.
+		/// </summary>
 		public int total;
 		public List<object> interactions; // I literally do not know what this does. Sorry
 	}
@@ -18,33 +24,111 @@ namespace Coolbooru {
 	/// Represents an item in the Derpibooru database.
 	/// </summary>
 	public class CoolItem {
+		/// <summary>
+		/// The Derpibooru ID of the image.
+		/// </summary>
 		public string id;
+		/// <summary>
+		/// The date the image was created.
+		/// </summary>
 		public DateTime created_at;
+		/// <summary>
+		/// The date the image was updated.
+		/// </summary>
 		public DateTime updated_at;
 		public List<object> duplicate_reports; // not sure what this does either
+		/// <summary>
+		/// The date the image was first seen.
+		/// </summary>
 		public DateTime first_seen_at;
+		/// <summary>
+		/// The user ID of the user who uploaded the image.
+		/// </summary>
 		public string uploader_id;
+		/// <summary>
+		/// The net score of the image on Derpibooru.
+		/// </summary>
 		public int score;
+		/// <summary>
+		/// The number of comments on the image.
+		/// </summary>
 		public int comment_count;
+		/// <summary>
+		/// The image's width in pixels.
+		/// </summary>
 		public int width;
+		/// <summary>
+		/// The image's height in pixels.
+		/// </summary>
 		public int height;
+		/// <summary>
+		/// The name of the image file according to Derpibooru.
+		/// </summary>
 		public string file_name;
+		/// <summary>
+		/// The image's description on Derpibooru.
+		/// </summary>
 		public string description;
+		/// <summary>
+		/// The image uploader's username.
+		/// </summary>
 		public string uploader;
+		/// <summary>
+		/// The URI (without protocol) to the image page on Derpibooru.
+		/// </summary>
 		public string image;
+		/// <summary>
+		/// The number of upvotes on the image.
+		/// </summary>
 		public int upvotes;
+		/// <summary>
+		/// The number of downvotes on the image.
+		/// </summary>
 		public int downvotes;
+		/// <summary>
+		/// The number of users that favorited the image.
+		/// </summary>
 		public int faves;
+		/// <summary>
+		/// A comma-separated list of tags on the image.
+		/// </summary>
 		public string tags;
+		/// <summary>
+		/// A List of the IDs of all the tags on the image.
+		/// </summary>
 		public List<string> tag_ids;
+		/// <summary>
+		/// The image's computed aspect ratio.
+		/// </summary>
 		public double aspect_ratio;
+		/// <summary>
+		/// The original format of the image before it was uploaded to Derpibooru.
+		/// </summary>
 		public string original_format;
+		/// <summary>
+		/// The MIME type of the image.
+		/// </summary>
 		public string mime_type;
+		/// <summary>
+		/// The image file's SHA512 hash.
+		/// </summary>
 		public string sha512_hash;
+		/// <summary>
+		/// The image file's SHA512 hash before it was optimized by Derpibooru.
+		/// </summary>
 		public string orig_sha512_hash;
+		/// <summary>
+		/// The image's source URL, if provided.
+		/// </summary>
 		public string source_url;
 		public CoolRepresentation representations;
+		/// <summary>
+		/// Whether or not the image was "rendered" by Derpibooru.
+		/// </summary>
 		public bool is_rendered;
+		/// <summary>
+		/// Whether or not the image was optimized by Derpibooru.
+		/// </summary>
 		public bool is_optimized;
 	}
 
@@ -52,11 +136,29 @@ namespace Coolbooru {
 	/// Represents a "Representation" (e.g. images) of the item
 	/// </summary>
 	public class CoolRepresentation {
+		/// <summary>
+		/// A very small thumbnail for the image.
+		/// </summary>
 		public string thumb_tiny;
+		/// <summary>
+		/// A small thumbnail for the image.
+		/// </summary>
 		public string thumb_small;
+		/// <summary>
+		/// A thumbnail for the image.
+		/// </summary>
 		public string thumb;
+		/// <summary>
+		/// A small version of the image.
+		/// </summary>
 		public string small;
+		/// <summary>
+		/// A medium version of the image.
+		/// </summary>
 		public string medium;
+		/// <summary>
+		/// A full-resolution version of the image.
+		/// </summary>
 		public string full;
 	}
 
@@ -82,39 +184,78 @@ namespace Coolbooru {
 	/// Represents arguments to a search query.
 	/// </summary>
 	public class CoolSearchQuery {
-		private string pq;
-		private string psf;
+		private string pQuery = "*";
+		private string pSortFormat;
 
-		public string q {
-			get { return pq; }
-			set { pq = Uri.EscapeUriString(value); }
+		/// <summary>
+		/// Your Derpibooru API key.
+		/// </summary>
+		public string APIKey;
+		/// <summary>
+		/// The Derpibooru query to search for. Defaults to *, for all tags.
+		/// </summary>
+		public string Query {
+			get { return pQuery; }
+			set { pQuery = Uri.EscapeUriString(value); }
 		}
-		public string sf {
-			get { return psf; }
-			set { psf = Uri.EscapeUriString(value); }
+		/// <summary>
+		/// The sort format to sort the results by. See the SORT_* constants.
+		/// </summary>
+		public string SortFormat {
+			get { return pSortFormat; }
+			set { pSortFormat = Uri.EscapeUriString(value); }
 		}
-		public string key;
-		public int page = 1;
-		public bool comments = false;
-		public bool fav = false;
+		/// <summary>
+		/// The page of results to return. Defaults to 1.
+		/// </summary>
+		public int Page = 1;
+		/// <summary>
+		/// Whether or not we should include the comments. *NOTE* This is resouce-intensive for both you and Derpibooru. Consider fetching this information on a per-image basis.
+		/// </summary>
+		public bool IncludeComments = false;
+		/// <summary>
+		/// Whether or not we should include the favorited-by information. *NOTE* This is resouce-intensive for both you and Derpibooru. Consider fetching this information on a per-image basis.
+		/// </summary>
+		public bool IncludeFavoritedBy = false;
 	}
 
 	/// <summary>
 	/// Represents arguments to a list query.
 	/// </summary>
 	public class CoolListQuery {
-		public string list;
-		public int page = 1;
-		public string last;
-		public bool comments = false;
-		public bool fav = false;
-		public string key;
+		/// <summary>
+		/// Your Derpibooru API key.
+		/// </summary>
+		public string APIKey;
+		/// <summary>
+		/// The List to search for.
+		/// </summary>
+		public string List;
+		/// <summary>
+		/// The page of results to return. Defaults to 1.
+		/// </summary>
+		public int Page = 1;
+		/// <summary>
+		/// The sampling period to construct the lists from. Specified in hours (Xh), days (Xd), or weeks (Xw).
+		/// </summary>
+		public string SamplingPeriod;
+		/// <summary>
+		/// Whether or not we should include the comments. *NOTE* This is resouce-intensive for both you and Derpibooru. Consider fetching this information on a per-image basis.
+		/// </summary>
+		public bool IncludeComments = false;
+		/// <summary>
+		/// Whether or not we should include the favorited-by information. *NOTE* This is resouce-intensive for both you and Derpibooru. Consider fetching this information on a per-image basis.
+		/// </summary>
+		public bool IncludeFavoritedBy = false;
 	}
 
 	/// <summary>
 	/// Represents a List.
 	/// </summary>
 	public class CoolList {
+		/// <summary>
+		/// The images in the list.
+		/// </summary>
 		public List<CoolItem> image;
 		public List<object> interactions;
 	}
@@ -123,14 +264,41 @@ namespace Coolbooru {
 	/// Represents a Gallery.
 	/// </summary>
 	public class CoolGallery {
+		/// <summary>
+		/// The date the gallery was created.
+		/// </summary>
 		public DateTime created_at;
-		public int creator_id;
-		public string description;
-		public int id;
-		public int image_count;
-		public string spoiler_warning;
-		public string title;
+		/// <summary>
+		/// The date at which the gallery was updated.
+		/// </summary>
 		public DateTime updated_at;
+		/// <summary>
+		/// The ID of the user who created the gallery.
+		/// </summary>
+		public int creator_id;
+		/// <summary>
+		/// The gallery's description.
+		/// </summary>
+		public string description;
+		/// <summary>
+		/// The ID of the gallery.
+		/// </summary>
+		public int id;
+		/// <summary>
+		/// The number of images in the gallery.
+		/// </summary>
+		public int image_count;
+		/// <summary>
+		/// The spoiler warning set on the gallery.
+		/// </summary>
+		public string spoiler_warning;
+		/// <summary>
+		/// The gallery's title.
+		/// </summary>
+		public string title;
+		/// <summary>
+		/// The number of users watching the gallery.
+		/// </summary>
 		public int watcher_count;
 	}
 
@@ -138,15 +306,59 @@ namespace Coolbooru {
 	/// Represents arguments to an front-page image list query.
 	/// </summary>
 	public class CoolImageQuery {
-		public string constraint;
-		public string key;
-		public int page = 1;
-		public int? gt;
-		public int? gte;
-		public int? lt;
-		public int? lte;
 		private char? pOrder = null;
-		public char? order {
+
+		/// <summary>
+		/// Your Derpibooru API key.
+		/// </summary>
+		public string APIKey;
+		/// <summary>
+		/// The field to search and sort by. See the CONSTRAINT_* constants.
+		/// </summary>
+		/// <see cref="Coolbooru.CONSTRAINT_ID"/>
+		/// <seealso cref="Coolbooru.CONSTRAINT_CREATED"/>
+		/// <seealso cref="Coolbooru.CONSTRAINT_UPDATED"/>
+		public string Constraint;
+		/// <summary>
+		/// The page of results to return. Defaults to 1.
+		/// </summary>
+		public int Page = 1;
+		/// <summary>
+		/// When specified, states that the ID must be greater than the given value. Use in conjunction with the id constraint.
+		/// </summary>
+		public int? IDGreaterThan;
+		/// <summary>
+		/// When specified, states that the ID must be greater than or equal to the given value. Use in conjunction with the id constraint.
+		/// </summary>
+		public int? IDGreaterThanOrEqualTo;
+		/// <summary>
+		/// When specified, states that the ID must be less than the given value. Use in conjunction with the id constraint.
+		/// </summary>
+		public int? IDLessThan;
+		/// <summary>
+		/// When specified, states that the ID must be less than or equal to the given value. Use in conjunction with the id constraint.
+		/// </summary>
+		public int? IDLessThanOrEqualTo;
+		/// <summary>
+		/// When specified, states that the time must be greater than the given value. Use in conjunction with the created_at and updated_at constraints.
+		/// </summary>
+		public string TimeGreaterThan;
+		/// <summary>
+		/// When specified, states that the time must be greater than or equal to the given value. Use in conjunction with the created_at and updated_at constraints.
+		/// </summary>
+		public string TimeGreaterThanOrEqualTo;
+		/// <summary>
+		/// When specified, states that the time must be less than the given value. Use in conjunction with the created_at and updated_at constraints.
+		/// </summary>
+		public string TimeLessThan;
+		/// <summary>
+		/// When specified, states that the time must be less than or equal to the given value. Use in conjunction with the created_at and updated_at constraints.
+		/// </summary>
+		public string TimeLessThanOrEqualTo;
+		/// <summary>
+		/// The way to sort the images (a for ascending, d for descending).
+		/// </summary>
+		public char? Order {
 			get {
 				return pOrder;
 			}
@@ -157,39 +369,105 @@ namespace Coolbooru {
 				pOrder = value;
 			}
 		}
-		public bool deleted;
-		public bool comments = false;
-		public bool fav = false;
-		public bool random_image;
+		/// <summary>
+		/// Whether or not to include information about duplicate or deleted images in the results. Metadata is limited to id, created_at, updated_at, and either deletion_reason or duplicate_of.
+		/// </summary>
+		public bool Deleted;
+		/// <summary>
+		/// Whether or not we should include the comments. *NOTE* This is resouce-intensive for both you and Derpibooru. Consider fetching this information on a per-image basis.
+		/// </summary>
+		public bool IncludeComments = false;
+		/// <summary>
+		/// Whether or not we should include the favorited-by information. *NOTE* This is resouce-intensive for both you and Derpibooru. Consider fetching this information on a per-image basis.
+		/// </summary>
+		public bool IncludeFavoritedBy = false;
+		/// <summary>
+		/// When specified, sorts the images randomly.
+		/// </summary>
+		public bool SortRandomly;
 	}
 
 	/// <summary>
 	/// Represents arguments to a user gallery query.
 	/// </summary>
 	public class CoolUserGalleryQuery {
-		public string user;
-		public int? id;
-		public string key;
-		public int page = 1;
-		public bool include_images = false;
+		/// <summary>
+		/// Your Derpibooru API key.
+		/// </summary>
+		public string APIKey;
+		/// <summary>
+		/// THe username of the user to pull galleries from.
+		/// </summary>
+		public string User;
+		/// <summary>
+		/// The ID of the gallery to pull. Optional.
+		/// </summary>
+		public int? ID;
+		/// <summary>
+		/// The page of results to return. Defaults to 1.
+		/// </summary>
+		public int Page = 1;
+		/// <summary>
+		/// Whether or not to return an array of image IDs featured in each gallery, in the order defined by the owner. Disregards content filters.
+		/// </summary>
+		public bool IncludeImages = false;
 	}
 
 	/// <summary>
-	/// Represents an OEmbed response.
+	/// Represents an oEmbed response.
 	/// </summary>
 	public class CoolEmbed {
+		/// <summary>
+		/// The version of oEmbed used.
+		/// </summary>
 		public string version;
+		/// <summary>
+		/// The type of oEmbed response.
+		/// </summary>
 		public string type;
+		/// <summary>
+		/// The title parameter of the oEmbed structure.
+		/// </summary>
 		public string title;
+		/// <summary>
+		/// The author's URL.
+		/// </summary>
 		public string author_url;
+		/// <summary>
+		/// The author's name (specified by artist: tag).
+		/// </summary>
 		public string author_name;
+		/// <summary>
+		/// The provider name (usually Derpibooru).
+		/// </summary>
 		public string provider_name;
+		/// <summary>
+		/// The URL of the image page on Derpibooru.
+		/// </summary>
 		public string provider_url;
+		/// <summary>
+		/// A Unix timestamp that specifies an age for caching purposes. Derpibooru recommends you cache your oEmbed responses!
+		/// </summary>
 		public int cache_age;
+		/// <summary>
+		/// The Derpibooru ID of the image.
+		/// </summary>
 		public int derpibooru_id;
+		/// <summary>
+		/// The net score on Derpibooru for the image.
+		/// </summary>
 		public int derpibooru_score;
+		/// <summary>
+		/// The number of comments on the image.
+		/// </summary>
 		public int derpibooru_comments;
+		/// <summary>
+		/// A list of tags applied to the image.
+		/// </summary>
 		public List<string> derpibooru_tags;
+		/// <summary>
+		/// The direct link to the image.
+		/// </summary>
 		public string thumbnail_url;
 	}
 
@@ -197,15 +475,42 @@ namespace Coolbooru {
 	/// The main functions of Coolbooru.
 	/// </summary>
 	public class Coolbooru {
+		/// <summary>
+		/// The ID constraint for use with List searches.
+		/// </summary>
 		public const string CONSTRAINT_ID = "id";
+		/// <summary>
+		/// The updated_at constraint to used with List searches.
+		/// </summary>
 		public const string CONSTRAINT_UPDATED = "updated";
+		/// <summary>
+		/// The created_at constraint to be used with List searches.
+		/// </summary>
 		public const string CONSTRAINT_CREATED = "created";
 
+		/// <summary>
+		/// Sort by the time the image was uploaded.
+		/// </summary>
 		public const string SORT_CREATEDAT = "created_at";
+		/// <summary>
+		/// Sort by the image's score.
+		/// </summary>
 		public const string SORT_SCORE = "score";
+		/// <summary>
+		/// Sort by the Derpibooru-determined "relevance" to your query.
+		/// </summary>
 		public const string SORT_RELEVANCE = "relevance";
+		/// <summary>
+		/// Sort by image width.
+		/// </summary>
 		public const string SORT_WIDTH = "width";
+		/// <summary>
+		/// Sort by image height.
+		/// </summary>
 		public const string SORT_HEIGHT = "height";
+		/// <summary>
+		/// Sort randomly!
+		/// </summary>
 		public const string SORT_RANDOM = "random";
 
 		/// <summary>
@@ -245,11 +550,11 @@ namespace Coolbooru {
 		/// <param name="q">A CoolSearchQuery object</param>
 		/// <returns>A CoolSearch representing the result</returns>
 		public static async Task<CoolSearch> Search(CoolSearchQuery q) {
-			string url = "https://derpibooru.org/search.json?q=" + q.q + "&page=" + q.page;
-			if (q.key != null) url += "&key=" + q.key;
-			if (q.comments) url += "&comments=true";
-			if (q.fav) url += "&fav=true";
-			if (q.sf != null) url += "&sf=" + q.sf;
+			string url = "https://derpibooru.org/search.json?q=" + q.Query + "&page=" + q.Page;
+			if (q.APIKey != null) url += "&key=" + q.APIKey;
+			if (q.IncludeComments) url += "&comments=true";
+			if (q.IncludeFavoritedBy) url += "&fav=true";
+			if (q.SortFormat != null) url += "&sf=" + q.SortFormat;
 
 			return await DoResponse<CoolSearch>(url);
 		}
@@ -287,10 +592,10 @@ namespace Coolbooru {
 		/// <param name="q">A CoolListQuery representing the parameters of the request.</param>
 		/// <returns>A CoolList object representing the result</returns>
 		public static async Task<CoolList> List(CoolListQuery q) {
-			string url = "https://derpibooru.org/lists/" + q.list + ".json?page=" + q.page;
-			if (q.key != null) url += "&key=" + q.key;
-			if (q.comments) url += "&comments=true";
-			if (q.fav) url += "&fav=true";
+			string url = "https://derpibooru.org/lists/" + q.List + ".json?page=" + q.Page;
+			if (q.APIKey != null) url += "&key=" + q.APIKey;
+			if (q.IncludeComments) url += "&comments=true";
+			if (q.IncludeFavoritedBy) url += "&fav=true";
 
 			return await DoResponse<CoolList>(url);
 		}
@@ -347,16 +652,16 @@ namespace Coolbooru {
 		/// <returns>A CoolGallery representing the result.</returns>
 		public static async Task<CoolGallery> UserGallery(CoolUserGalleryQuery q) {
 			string url = "https://derpibooru.org/galleries/";
-			if (q.user != null && q.id != null)
-				url += q.user + "/" + q.id + ".json";
+			if (q.User != null && q.ID != null)
+				url += q.User + "/" + q.ID + ".json";
 			else {
-				if (q.user != null) url += q.user + ".json";
-				if (q.id != null) url += q.id + ".json";
+				if (q.User != null) url += q.User + ".json";
+				if (q.ID != null) url += q.ID + ".json";
 			}
 
-			url += "?page=" + q.page;
-			if (q.include_images) url += "&include_images=true";
-			if (q.key != null) url += "&key=" + q.key;
+			url += "?page=" + q.Page;
+			if (q.IncludeImages) url += "&include_images=true";
+			if (q.APIKey != null) url += "&key=" + q.APIKey;
 
 			return await DoResponse<CoolGallery>(url);
 		}
@@ -376,17 +681,33 @@ namespace Coolbooru {
 		/// <returns>A CoolImages object representing the result.</returns>
 		public static async Task<CoolImages> Images(CoolImageQuery q) {
 			string url = "https://derpibooru.org/images.json?page=" + q.page;
-			if (q.key != null) url += "&key=" + q.key;
-			if (q.constraint != null) url += "&constraint=" + q.constraint;
-			if (q.gt != null) url += "&gt=" + q.gt;
-			if (q.gte != null) url += "&gte=" + q.gte;
-			if (q.lt != null) url += "&lt=" + q.lt;
-			if (q.lte != null) url += "&lte=" + q.lte;
-			if (q.order != null) url += "&order=" + q.order;
-			if (q.deleted) url += "&deleted=true";
-			if (q.comments) url += "&comments=true";
-			if (q.fav) url += "&fav=true";
-			if (q.random_image) url += "&random_image=true";
+			if (q.APIKey != null) url += "&key=" + q.key;
+			if (q.Constraint != null) {
+				if (q.Constraint == CONSTRAINT_ID) {
+					if (q.IDGreaterThan != null)
+						url += "&gt=" + q.IDGreaterThan;
+					else if (q.IDGreaterThanOrEqualTo != null)
+						url += "&gte=" + q.IDGreaterThanOrEqualTo;
+					else if (q.IDLessThan != null)
+						url += "&lt=" + q.IDLessThan;
+					else if (q.IDLessThanOrEqualTo != null)
+						url += "&lte=" + q.IDLessThanOrEqualTo;
+				} else if (q.Constraint == CONSTRAINT_CREATED || q.Constraint == CONSTRAINT_UPDATED) {
+					if (q.TimeGreaterThan != null)
+						url += "&gt=" + q.TimeGreaterThan;
+					else if (q.TimeGreaterThanOrEqualTo != null)
+						url += "&gte=" + q.TimeGreaterThanOrEqualTo;
+					else if (q.TimeLessThan != null)
+						url += "&lt=" + q.TimeLessThan;
+					else if (q.TimeLessThanOrEqualTo != null)
+						url += "&lte=" + q.TimeLessThanOrEqualTo;
+				}
+			}
+			if (q.Order != null) url += "&order=" + q.Order;
+			if (q.Deleted) url += "&deleted=true";
+			if (q.IncludeComments) url += "&comments=true";
+			if (q.IncludeFavoritedBy) url += "&fav=true";
+			if (q.SortRandomly) url += "&random_image=true";
 
 			return await DoResponse<CoolImages>(url);
 		}


### PR DESCRIPTION
* Fit Microsoft's recommended C# naming convention by PascalCasing all method and property names.
* Give all Query classes better property names.
* Make `CONSTRAINT_CREATED` and `CONSTRAINT_UPDATED` actually useful.
* Rename the `Coolbooru` class to `CoolRequests` (**note:** needs review for a better name). Removes the necessity for `using static Coolbooru.Coolbooru` and makes code using Coolbooru look nicer.
* Add a boatload of documentation to properties of query and result objects.